### PR TITLE
fix(ci): allow PRs to check all releases

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -60,60 +60,66 @@ jobs:
             echo "version=$version"
             echo "date=$date"
             echo "---------------"
+
+            # check if tag exists
             cd ../sdk  # change directory to sdk to ensure we are in the correct git repo
             if git show-ref --tags $version --quiet; then
-              echo "$version tag exists, skipping"
-              cd ../temp  # change directory back to temp, since we are using relative paths
-            else
-              cd ../temp  # change directory back to temp, since we are using relative paths
-              echo "$version tag doesn't exist or error in command"
-
-              # move .git directory
-              mv ../sdk/.git ../temp_git
-
-              # remove all files
-              rm -f -r ../sdk/*
-              rm -f ../sdk/.keep
-
-              # move .git directory back
-              mv ../temp_git ../sdk/.git
-
-              # download tar
-              wget -q --show-progress --progress=bar:force:noscroll -O $version.tar ${base_url}/$tar_file
-              # extract tar
-              tar -xf $version.tar --strip-components=1
-
-              # remove tar
-              rm -f $version.tar
-          
-              # Find all the files in the extracted files and store them in an array
-              readarray -d '' tar_files < <(find . -type f -print0)
-
-              # Iterate over each file
-              # if the archive name is part of a directory name, rename it (removing the archive name)
-              # copy the file to the sdk directory
-              for file in "${tar_files[@]}"; do
-                echo "file=$file"
-                # remove archive_name/ from the directory it may occur multiple times
-                new_file=$(echo $file | sed -e "s/$archive_name\///g")
-                mkdir -p "../sdk/$(dirname "$new_file")"
-                mv -f "$file" "../sdk/$new_file"
-              done
-
-              # list files
-              ls -a ../sdk
-
               if [ ${{ github.event_name }} != 'pull_request' ]; then
-                echo "this is not a pull request, so we will attempt to update the sdk branch"
-                cd ../sdk
-
-                # add, commit, tag, push (with token/password/authentication)
-                git add .
-                git commit -m "${version}"
-                git tag $version
-                git push "https://oauth2:${{ secrets.GH_BOT_TOKEN }}@github.com/${{ github.repository }}.git" sdk $version
-          
-                cd ../temp
+                echo "$version tag exists, skipping"
+                continue
+              else
+                echo "$version tag exists, not skipping since this is a pull request"
               fi
+            else
+              echo "$version tag doesn't exist"
+            fi
+            cd ../temp  # change directory back to temp, since we are using relative paths
+
+            # move .git directory
+            mv ../sdk/.git ../temp_git
+
+            # remove all files
+            rm -f -r ../sdk/*
+            rm -f ../sdk/.keep
+
+            # move .git directory back
+            mv ../temp_git ../sdk/.git
+
+            # download tar
+            wget -q --show-progress --progress=bar:force:noscroll -O $version.tar ${base_url}/$tar_file
+            # extract tar
+            tar -xf $version.tar --strip-components=1
+
+            # remove tar
+            rm -f $version.tar
+        
+            # Find all the files in the extracted files and store them in an array
+            readarray -d '' tar_files < <(find . -type f -print0)
+
+            # Iterate over each file
+            # if the archive name is part of a directory name, rename it (removing the archive name)
+            # move the file to the sdk directory
+            for file in "${tar_files[@]}"; do
+              echo "file=$file"
+              # remove archive_name/ from the directory it may occur multiple times
+              new_file=$(echo $file | sed -e "s/$archive_name\///g")
+              mkdir -p "../sdk/$(dirname "$new_file")"
+              mv -f "$file" "../sdk/$new_file"
+            done
+
+            # list files
+            ls -a ../sdk
+
+            if [ ${{ github.event_name }} != 'pull_request' ]; then
+              echo "this is not a pull request, so we will attempt to update the sdk branch"
+              cd ../sdk
+
+              # add, commit, tag, push (with token/password/authentication)
+              git add .
+              git commit -m "${version}"
+              git tag $version
+              git push "https://oauth2:${{ secrets.GH_BOT_TOKEN }}@github.com/${{ github.repository }}.git" sdk $version
+        
+              cd ../temp
             fi
           done < ../downloads.txt


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
PRs will now check all releases, but won't do any push.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
